### PR TITLE
add Docker-Indexer workflow

### DIFF
--- a/.github/workflows/docker-indexer.yml
+++ b/.github/workflows/docker-indexer.yml
@@ -1,0 +1,58 @@
+name: Docker-Indexer
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "indexer"
+    tags:
+      - "v*-indexer"
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+  pull_request:
+    branches:
+      - "indexer"
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: minimove-indexer
+
+jobs:
+  minitiad-indexer:
+    name: Minitiad-Indexer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          build-args: "GITHUB_ACCESS_TOKEN=${{ secrets.GH_READ_TOKEN }}"
+          file: images/private/Dockerfile
+          push: ${{ startsWith(github.ref, 'refs/tags') }} # push image only for tags
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
to build indexer image when the tag with postfix `-indexer` is made from the `indexer` branch