### PR TITLE
Implement CI/CD workflows for Initia binary builds

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,0 +1,19 @@
+name: Build and Upload to releases
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-linux-amd64:
+    uses: ./.github/workflows/build-linux-amd64.yml
+
+  build-linux-arm64:
+    uses: ./.github/workflows/build-linux-arm64.yml
+
+  build-darwin-amd64:
+    uses: ./.github/workflows/build-darwin-amd64.yml
+
+  build-darwin-arm64:
+    uses: ./.github/workflows/build-darwin-arm64.yml

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -1,0 +1,65 @@
+name: Build Darwin AMD64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+
+      - name: Set environment variables
+        run: |
+          MINIMOVE_NETWORK_NAME="minimove-1"
+          echo "MINIMOVE_NETWORK_NAME=${MINIMOVE_NETWORK_NAME}" >> $GITHUB_ENV        
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+          echo "GOOS=darwin" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
+          MOVEVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          echo "MOVEVM_VERSION=${MOVEVM_VERSION}" >> $GITHUB_ENV        
+
+      - name: Ensure dependencies
+        run: |
+          go mod tidy
+          go get github.com/initia-labs/movevm@${MOVEVM_VERSION}
+
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+          echo "ARCH_NAME=${ARCH_NAME}"
+          echo "MOVEVM_VERSION=${MOVEVM_VERSION}"
+          echo "MINIMOVE_NETWORK_NAME=${MINIMOVE_NETWORK_NAME}"
+
+      - name: Build and Package for Darwin ADM64
+        run: |
+          cd ../minimove \
+          && make build \
+          && cd ./build \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
+          && tar -czvf minimove_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+          && mv ./minimove_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+  
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            minimove_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -1,0 +1,63 @@
+
+name: Build Darwin ARM64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+      - name: Set environment variables
+        run: |
+          MINIMOVE_NETWORK_NAME="minimove-1"
+          echo "MINIMOVE_NETWORK_NAME=${MINIMOVE_NETWORK_NAME}" >> $GITHUB_ENV
+          MOVEVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          echo "MOVEVM_VERSION=${MOVEVM_VERSION}" >> $GITHUB_ENV        
+          echo "GOARCH=arm64" >> $GITHUB_ENV
+          echo "GOOS=darwin" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=aarch64" >> $GITHUB_ENV
+          
+      - name: Ensure dependencies
+        run: |
+          go mod tidy
+          go get github.com/initia-labs/movevm@${MOVEVM_VERSION}
+          
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+          echo "ARCH_NAME=${ARCH_NAME}"
+          echo "MINIMOVE_NETWORK_NAME=${MINIMOVE_NETWORK_NAME}"
+      
+      - name: Build and Package for Darwin ARM64
+        run: |
+          cd ../minimove \
+          && make build \
+          && cd ./build \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
+          && tar -czvf minimove"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+          && mv ./minimove_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+  
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            minimove${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -52,7 +52,7 @@ jobs:
           && cd ./build \
           && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
           && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
-          && tar -czvf minimove"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+          && tar -czvf minimove_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
           && mv ./minimove_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
   

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -60,4 +60,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            minimove${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz
+            minimove_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -1,0 +1,53 @@
+
+name: Build Linux AMD64
+
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+
+      - name: Set environment variables
+        run: |
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+          echo "GOOS=linux" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
+
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+
+      - name: Build for Linux AMD64
+        run: |
+          export GOARCH=${GOARCH}
+          export GOOS=${GOOS}
+          make build-linux-with-shared-library
+          cd ./build
+          mkdir -p minimove_${VERSION}
+          mv libmovevm.so minimove_${VERSION}/libmovevm.${ARCH_NAME}.so
+          mv libcompiler.so minimove_${VERSION}/libcompiler.${ARCH_NAME}.so
+          mv minitiad minimove_${VERSION}/
+          tar -czvf minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz minimove_${VERSION}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ./build/minimove_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,79 @@
+
+name: Build Linux ARM64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set environment variables
+        run: |
+          echo "GOARCH=arm64" >> $GITHUB_ENV
+          echo "GOOS=linux" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=aarch64" >> $GITHUB_ENV
+          
+      - name: Build for ARM64
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          # BuildKit 활성화 및 새 빌더 생성
+          docker buildx create --use --name arm64-builder --platform linux/arm64
+          docker buildx inspect --bootstrap
+
+          # ARM64용 이미지 빌드
+          docker buildx build --platform linux/arm64 --load --tag minitia/minitiad-shared:arm64 . -f Dockerfile.arm64
+
+          # ARM64 이미지를 사용하여 빌드 결과물 추출
+          mkdir -p ./build
+          docker create --name temp minitia/minitiad-shared:arm64
+          docker cp temp:/usr/local/bin/minitiad ./build/
+          docker cp temp:/lib/libmovevm.so ./build/
+          docker cp temp:/lib/libcompiler.so ./build/
+          docker rm temp
+
+          # 결과물 패키징
+          cd ./build
+          mkdir -p minimove_${VERSION}
+          mv minitiad minimove_${VERSION}/
+          mv libmovevm.so minimove_${VERSION}/libmovevm.${ARCH_NAME}.so
+          mv libcompiler.so minimove_${VERSION}/libcompiler.${ARCH_NAME}.so
+          tar -czvf minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz minimove_${VERSION}
+          mv minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz ../
+
+          # 빌드 결과 확인
+          cd ..
+          ls -l
+          file minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz
+
+          # 빌더 제거
+          docker buildx rm arm64-builder
+
+      - name: List files
+        run: ls -l
+        
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+              ./minimove_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -37,14 +37,14 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          # BuildKit 활성화 및 새 빌더 생성
+          # Activate BuildKit and create a new builder
           docker buildx create --use --name arm64-builder --platform linux/arm64
           docker buildx inspect --bootstrap
 
-          # ARM64용 이미지 빌드
+          # Building images for ARM64
           docker buildx build --platform linux/arm64 --load --tag minitia/minitiad-shared:arm64 . -f Dockerfile.arm64
 
-          # ARM64 이미지를 사용하여 빌드 결과물 추출
+          # Extract build output using ARM64 images
           mkdir -p ./build
           docker create --name temp minitia/minitiad-shared:arm64
           docker cp temp:/usr/local/bin/minitiad ./build/
@@ -52,7 +52,7 @@ jobs:
           docker cp temp:/lib/libcompiler.so ./build/
           docker rm temp
 
-          # 결과물 패키징
+          # Packaging of results
           cd ./build
           mkdir -p minimove_${VERSION}
           mv minitiad minimove_${VERSION}/
@@ -61,12 +61,12 @@ jobs:
           tar -czvf minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz minimove_${VERSION}
           mv minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz ../
 
-          # 빌드 결과 확인
+          # Check build results
           cd ..
           ls -l
           file minimove_${VERSION}_Linux_${ARCH_NAME}.tar.gz
 
-          # 빌더 제거
+          # remove builder
           docker buildx rm arm64-builder
 
       - name: List files

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,35 @@
+
+FROM arm64v8/golang:1.22-bullseye AS go-builder
+
+# Install minimum necessary dependencies, build Cosmos SDK, remove packages
+RUN apt update
+RUN apt install -y curl git build-essential
+# debug: for live editing in the image
+RUN apt install -y vim
+
+WORKDIR /code
+COPY . /code/
+
+RUN LEDGER_ENABLED=false make build
+
+RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libmovevm.`uname -m`.so /lib/libmovevm.so
+RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libcompiler.`uname -m`.so /lib/libcompiler.so
+
+FROM arm64v8/ubuntu:20.04
+
+WORKDIR /root
+
+COPY --from=go-builder /code/build/minitiad /usr/local/bin/minitiad
+COPY --from=go-builder /lib/libmovevm.so /lib/libmovevm.so
+COPY --from=go-builder /lib/libcompiler.so /lib/libcompiler.so
+
+# rest server
+EXPOSE 1317
+# grpc
+EXPOSE 9090
+# tendermint p2p
+EXPOSE 26656
+# tendermint rpc
+EXPOSE 26657
+
+CMD ["/usr/local/bin/minitiad", "version"]


### PR DESCRIPTION
## Changes

- Add build-and-upload.yml: Main workflow coordinating build processes
    - Set up matrix strategy for multiple platforms (Linux, Darwin)
    - Trigger builds for amd64 and arm64 architectures
- Add build-darwin-amd64.yml and build-darwin-arm64.yml: Darwin-specific build workflows
    - Configure macOS environment and build process
    - Support amd64 and arm64 architectures separately
- Add build-linux-amd64.yml and build-linux-arm64.yml: Linux-specific build workflows
    - Set up Ubuntu environment and build process
    - Include steps for amd64 and arm64 builds separately
- Implement automatic uploads to GitHub Releases for all builds

## Rationale and Improvement

This PR sets up comprehensive CI/CD pipelines for building minimove binaries across multiple platforms and architectures, ensuring consistent and automated releases. These workflows significantly improve the developer experience by automating the build and release process, reducing manual errors, and ensuring that binaries are available for all supported platforms and architectures.

## Additional Notes

- This PR improves the overall release process and should make it easier for users to access the latest minimove binaries for their specific platform.
- The automated nature of these workflows will help maintain consistency across releases and reduce the workload on maintainers.

## Reviewer Considerations

- Please review the workflow files for any potential security concerns or optimizations.