### PR TITLE
bump kvindexer and move-nft

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,9 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/initia-labs/OPinit v0.3.2
 	github.com/initia-labs/initia v0.3.4
-	github.com/initia-labs/kvindexer v0.1.3
+	github.com/initia-labs/kvindexer v0.1.6
 	github.com/initia-labs/kvindexer/submodules/block v0.1.0
-	github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3
+	github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4
 	github.com/initia-labs/kvindexer/submodules/pair v0.1.1
 	github.com/initia-labs/kvindexer/submodules/tx v0.1.0
 	// we also need to update `LIBMOVEVM_VERSION` of images/private/Dockerfile#5
@@ -63,6 +63,7 @@ require (
 	github.com/DataDog/datadog-go v3.2.0+incompatible // indirect
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/IGLOU-EU/go-wildcard v1.0.3 // indirect
+	github.com/allegro/bigcache/v3 v3.1.0 // indirect
 	github.com/aptos-labs/serde-reflection/serde-generate/runtime/golang v0.0.0-20231213012317-73b6bbf74833 // indirect
 	github.com/avast/retry-go/v4 v4.5.1 // indirect
 	github.com/aws/aws-sdk-go v1.44.312 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -802,10 +804,14 @@ github.com/initia-labs/initia v0.3.4 h1:i2fwTx9WDwGp2nyX64r6jtdtgfJmRqKAXGdxbHBR
 github.com/initia-labs/initia v0.3.4/go.mod h1:nwtnVe3obacErGb7w6tq8Ych3U0d2f59rsgpVUeMnmM=
 github.com/initia-labs/kvindexer v0.1.3 h1:TLkgJjp5TiPnH+OzYfk7ZKQTKqGOfSte59Y3gasob+o=
 github.com/initia-labs/kvindexer v0.1.3/go.mod h1:rvAmgCAmEs4KM8sRRPcyTqNNwi8s2JiHybiFkYfp4KE=
+github.com/initia-labs/kvindexer v0.1.6 h1:RAnd89v/ZNtmsmBiD5ubBe1455UvIbH3dMxvPUYc5A8=
+github.com/initia-labs/kvindexer v0.1.6/go.mod h1:OV85HaQ9KVrg+zGPUlxT9RF9nAaM3Yq4/3MoHqGqhWk=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0 h1:y+EXnksd/I2F96mzIoQA64nZUZON2P+99YrSzeLCLoY=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0/go.mod h1:4c+c59wVAnjuaJv/pcDYaUkeVmOqVV+orqEjya/RIjo=
 github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3 h1:0Gx1x2ZeIa8/UQ6aSUx/ePDHNCOd3HS8EL3WIQGf1lU=
 github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3/go.mod h1:cMkE+Wu9sd8DLMXI/kDA9JjmmTBTnlKSQhLfnvKE1Fk=
+github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4 h1:/AxX0zoNJ94BRFsWxYPisBC0ah4vEVQ0WCZhPZAwonE=
+github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4/go.mod h1:cMkE+Wu9sd8DLMXI/kDA9JjmmTBTnlKSQhLfnvKE1Fk=
 github.com/initia-labs/kvindexer/submodules/pair v0.1.1 h1:o151gA4jIbqEl+pWTOCizkiOPgkA5ANuNbHfqAQijoE=
 github.com/initia-labs/kvindexer/submodules/pair v0.1.1/go.mod h1:8X1GE1ZLkH7z8TKb5MUh7UClTkcqVFIwXIIRdsqeUZY=
 github.com/initia-labs/kvindexer/submodules/tx v0.1.0 h1:6kbf6wmzXPN0XCQLasiFgq1AlZHkt5K3/ZG+IWw1nNs=


### PR DESCRIPTION
1. kvindexer update to fix cache capacity unit from bytes to MiB
2. bump move-nft submodule to fix a bug: ignore previous failure and make indices for other events