### PR TITLE
bump kvindexer and move-nft submodule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,9 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/initia-labs/OPinit v0.3.2
 	github.com/initia-labs/initia v0.3.4
-	github.com/initia-labs/kvindexer v0.1.5
+	github.com/initia-labs/kvindexer v0.1.6
 	github.com/initia-labs/kvindexer/submodules/block v0.1.0
-	github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3
+	github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4
 	github.com/initia-labs/kvindexer/submodules/pair v0.1.1
 	github.com/initia-labs/kvindexer/submodules/tx v0.1.0
 	// we also need to update `LIBMOVEVM_VERSION` of images/private/Dockerfile#5

--- a/go.sum
+++ b/go.sum
@@ -802,14 +802,10 @@ github.com/initia-labs/ibc-go/v8 v8.0.0-20240419124350-4275a05abe2c h1:FDwh5zZbm
 github.com/initia-labs/ibc-go/v8 v8.0.0-20240419124350-4275a05abe2c/go.mod h1:wj3qx75iC/XNnsMqbPDCIGs0G6Y3E/lo3bdqCyoCy+8=
 github.com/initia-labs/initia v0.3.4 h1:i2fwTx9WDwGp2nyX64r6jtdtgfJmRqKAXGdxbHBRg9s=
 github.com/initia-labs/initia v0.3.4/go.mod h1:nwtnVe3obacErGb7w6tq8Ych3U0d2f59rsgpVUeMnmM=
-github.com/initia-labs/kvindexer v0.1.5 h1:YLR4d237dNkGR8pe2zRGxx3CFB2CU6hhUmeJsshUw/0=
-github.com/initia-labs/kvindexer v0.1.5/go.mod h1:OV85HaQ9KVrg+zGPUlxT9RF9nAaM3Yq4/3MoHqGqhWk=
 github.com/initia-labs/kvindexer v0.1.6 h1:RAnd89v/ZNtmsmBiD5ubBe1455UvIbH3dMxvPUYc5A8=
 github.com/initia-labs/kvindexer v0.1.6/go.mod h1:OV85HaQ9KVrg+zGPUlxT9RF9nAaM3Yq4/3MoHqGqhWk=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0 h1:y+EXnksd/I2F96mzIoQA64nZUZON2P+99YrSzeLCLoY=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0/go.mod h1:4c+c59wVAnjuaJv/pcDYaUkeVmOqVV+orqEjya/RIjo=
-github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3 h1:0Gx1x2ZeIa8/UQ6aSUx/ePDHNCOd3HS8EL3WIQGf1lU=
-github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3/go.mod h1:cMkE+Wu9sd8DLMXI/kDA9JjmmTBTnlKSQhLfnvKE1Fk=
 github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4 h1:/AxX0zoNJ94BRFsWxYPisBC0ah4vEVQ0WCZhPZAwonE=
 github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4/go.mod h1:cMkE+Wu9sd8DLMXI/kDA9JjmmTBTnlKSQhLfnvKE1Fk=
 github.com/initia-labs/kvindexer/submodules/pair v0.1.1 h1:o151gA4jIbqEl+pWTOCizkiOPgkA5ANuNbHfqAQijoE=

--- a/go.sum
+++ b/go.sum
@@ -804,10 +804,14 @@ github.com/initia-labs/initia v0.3.4 h1:i2fwTx9WDwGp2nyX64r6jtdtgfJmRqKAXGdxbHBR
 github.com/initia-labs/initia v0.3.4/go.mod h1:nwtnVe3obacErGb7w6tq8Ych3U0d2f59rsgpVUeMnmM=
 github.com/initia-labs/kvindexer v0.1.5 h1:YLR4d237dNkGR8pe2zRGxx3CFB2CU6hhUmeJsshUw/0=
 github.com/initia-labs/kvindexer v0.1.5/go.mod h1:OV85HaQ9KVrg+zGPUlxT9RF9nAaM3Yq4/3MoHqGqhWk=
+github.com/initia-labs/kvindexer v0.1.6 h1:RAnd89v/ZNtmsmBiD5ubBe1455UvIbH3dMxvPUYc5A8=
+github.com/initia-labs/kvindexer v0.1.6/go.mod h1:OV85HaQ9KVrg+zGPUlxT9RF9nAaM3Yq4/3MoHqGqhWk=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0 h1:y+EXnksd/I2F96mzIoQA64nZUZON2P+99YrSzeLCLoY=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0/go.mod h1:4c+c59wVAnjuaJv/pcDYaUkeVmOqVV+orqEjya/RIjo=
 github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3 h1:0Gx1x2ZeIa8/UQ6aSUx/ePDHNCOd3HS8EL3WIQGf1lU=
 github.com/initia-labs/kvindexer/submodules/move-nft v0.1.3/go.mod h1:cMkE+Wu9sd8DLMXI/kDA9JjmmTBTnlKSQhLfnvKE1Fk=
+github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4 h1:/AxX0zoNJ94BRFsWxYPisBC0ah4vEVQ0WCZhPZAwonE=
+github.com/initia-labs/kvindexer/submodules/move-nft v0.1.4/go.mod h1:cMkE+Wu9sd8DLMXI/kDA9JjmmTBTnlKSQhLfnvKE1Fk=
 github.com/initia-labs/kvindexer/submodules/pair v0.1.1 h1:o151gA4jIbqEl+pWTOCizkiOPgkA5ANuNbHfqAQijoE=
 github.com/initia-labs/kvindexer/submodules/pair v0.1.1/go.mod h1:8X1GE1ZLkH7z8TKb5MUh7UClTkcqVFIwXIIRdsqeUZY=
 github.com/initia-labs/kvindexer/submodules/tx v0.1.0 h1:6kbf6wmzXPN0XCQLasiFgq1AlZHkt5K3/ZG+IWw1nNs=


### PR DESCRIPTION
1. kvindexer update to fix cache capacity unit from bytes to MiB
2. bump move-nft submodule to fix a bug: ignore previous failure and make indices for other events
3. includes: #47 
