### PR TITLE
fix: resolve concurrent release uploads in workflow

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -26,32 +26,34 @@ jobs:
       - build-darwin-amd64
       - build-darwin-arm64
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Download linux amd64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: minimove_linux_amd64.tar.gz
+          name: minimove-linux-amd64
 
       - name: Download linux arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: minimove_linux_arm64.tar.gz
+          name: minimove-linux-arm64
 
       - name: Download darwin amd64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: minimove_darwin_amd64.tar.gz
+          name: minimove-darwin-amd64
 
       - name: Download darwin arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: minimove_darwin_arm64.tar.gz
+          name: minimove-darwin-arm64
+
+      - name: List downloaded files
+        run: ls -la *.tar.gz
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            minimove_linux_amd64.tar.gz
-            minimove_linux_arm64.tar.gz
-            minimove_darwin_amd64.tar.gz
-            minimove_darwin_arm64.tar.gz
+            *.tar.gz

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -61,8 +61,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: minimove_darwin_amd64.tar.gz
+          name: minimove-darwin-amd64
           path: minimove_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz
+          retention-days: 1
         env:
           VERSION: ${{ env.VERSION }}
           ARCH_NAME: ${{ env.ARCH_NAME }}

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -49,8 +49,7 @@ jobs:
 
       - name: Build and Package for Darwin ADM64
         run: |
-          cd ../minimove \
-          && make build \
+          make build \
           && cd ./build \
           && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
           && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -46,8 +46,7 @@ jobs:
 
       - name: Build and Package for Darwin ARM64
         run: |
-          cd ../minimove \
-          && make build \
+          make build \
           && cd ./build \
           && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
           && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -58,8 +58,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: minimove_darwin_arm64.tar.gz
+          name: minimove-darwin-arm64
           path: minimove_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz
+          retention-days: 1
         env:
           VERSION: ${{ env.VERSION }}
           ARCH_NAME: ${{ env.ARCH_NAME }}

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -47,8 +47,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: minimove_linux_amd64.tar.gz
+          name: minimove-linux-amd64
           path: minimove_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz
+          retention-days: 1
         env:
           VERSION: ${{ env.VERSION }}
           ARCH_NAME: ${{ env.ARCH_NAME }}

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -73,8 +73,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: minimove_linux_arm64.tar.gz
+          name: minimove-linux-arm64
           path: minimove_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz
+          retention-days: 1
         env:
           VERSION: ${{ env.VERSION }}
           ARCH_NAME: ${{ env.ARCH_NAME }}


### PR DESCRIPTION
- Add missing permissions for release job
- Use meaningful artifact names instead of filenames
- Use wildcard pattern for release files
- Add artifact retention policy