### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: tidy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run codespell
         continue-on-error: true
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: 1.23
       - name: Install openssl
         run: sudo apt-get install libssl-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: technote-space/get-diff-action@v4
         with:
           PATTERNS: |


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded CI workflows to the latest checkout action across build, linting, spellcheck, testing, and Docker pipelines, improving reliability, security, and compatibility. Expect faster, more consistent runs and fewer transient failures. No changes to product behavior.
* **Tests**
  * Refreshed test and coverage pipelines with updated tooling for increased stability and smoother executions, without impacting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->