### PR TITLE
chore(build): update proto tooling and regenerate code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,16 @@ update-swagger-docs: statik
 ###                                Protobuf                                 ###
 ###############################################################################
 
-protoVer=0.14.0
+protoVer=0.18.1
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(protoImageName)
+
+# Keep swagger generation on the legacy proto-builder because the cloned
+# third-party proto repos still expect the older `swagger` plugin flow.
+# The other proto tasks can use the newer builder independently.
+swaggerProtoVer=0.14.0
+swaggerProtoImageName=ghcr.io/cosmos/proto-builder:$(swaggerProtoVer)
+swaggerProtoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(swaggerProtoImageName)
 
 proto-all: proto-format proto-lint proto-gen
 
@@ -163,7 +170,7 @@ proto-gen:
 
 proto-swagger-gen:
 	@echo "Generating Swagger files"
-	@$(protoImage) sh ./scripts/protoc-swagger-gen.sh
+	@$(swaggerProtoImage) sh ./scripts/protoc-swagger-gen.sh
 	$(MAKE) update-swagger-docs
 
 proto-pulsar-gen:

--- a/Makefile
+++ b/Makefile
@@ -162,11 +162,15 @@ swaggerProtoVer=0.14.0
 swaggerProtoImageName=ghcr.io/cosmos/proto-builder:$(swaggerProtoVer)
 swaggerProtoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(swaggerProtoImageName)
 
-proto-all: proto-format proto-lint proto-gen
+proto-all: proto-format proto-lint proto-gen proto-swagger-gen proto-pulsar-gen
 
 proto-gen:
-	@echo "Generating Protobuf files"
-	@$(protoImage) sh ./scripts/protocgen.sh
+	@if find ./proto -name "*.proto" -print -quit | grep -q .; then \
+		echo "Generating Protobuf files"; \
+		$(protoImage) sh ./scripts/protocgen.sh; \
+	else \
+		echo "No .proto files found under ./proto, skipping proto-gen"; \
+	fi
 
 proto-swagger-gen:
 	@echo "Generating Swagger files"
@@ -174,14 +178,26 @@ proto-swagger-gen:
 	$(MAKE) update-swagger-docs
 
 proto-pulsar-gen:
-	@echo "Generating Dep-Inj Protobuf files"
-	@$(protoImage) sh ./scripts/protocgen-pulsar.sh
+	@if find ./proto -name "*.proto" -print -quit | grep -q .; then \
+		echo "Generating Dep-Inj Protobuf files"; \
+		$(protoImage) sh ./scripts/protocgen-pulsar.sh; \
+	else \
+		echo "No .proto files found under ./proto, skipping proto-pulsar-gen"; \
+	fi
 
 proto-format:
-	@$(protoImage) find ./ -name "*.proto" -exec clang-format -i {} \;
+	@if find ./proto -name "*.proto" -print -quit | grep -q .; then \
+		$(protoImage) find ./ -name "*.proto" -exec clang-format -i {} \; \
+	else \
+		echo "No .proto files found under ./proto, skipping proto-format"; \
+	fi
 
 proto-lint:
-	@$(protoImage) buf lint --error-format=json
+	@if find ./proto -name "*.proto" -print -quit | grep -q .; then \
+		$(protoImage) buf lint --error-format=json ./proto; \
+	else \
+		echo "No .proto files found under ./proto, skipping proto-lint"; \
+	fi
 
 proto-check-breaking:
 	@$(protoImage) buf breaking --against $(HTTPS_GIT)#branch=main

--- a/client/docs/swagger-ui/swagger-cosmos.yaml
+++ b/client/docs/swagger-ui/swagger-cosmos.yaml
@@ -21500,7 +21500,7 @@ paths:
   /cosmos/consensus/v1/params:
     get:
       summary: Params queries the parameters of x/consensus module.
-      operationId: GroupParams
+      operationId: Params
       responses:
         '200':
           description: A successful response.

--- a/client/docs/swagger-ui/swagger-initia.yaml
+++ b/client/docs/swagger-ui/swagger-initia.yaml
@@ -754,7 +754,7 @@ paths:
         - Query
   /initia/move/v1/denom:
     get:
-      summary: Denom converts denom to metadata
+      summary: Denom converts metadata to denom
       operationId: Denom
       responses:
         '200':
@@ -796,9 +796,186 @@ paths:
           type: string
       tags:
         - Query
+  /initia/move/v1/dex/pairs:
+    get:
+      summary: DexPairs queries all dex pairs.
+      operationId: DexPairs
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              dex_pairs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    metadata_quote:
+                      type: string
+                    metadata_lp:
+                      type: string
+                  description: |-
+                    DexPair contains coin metadata address
+                    std::dex::Pool and std::dex::Config resources.
+              pagination:
+                description: pagination defines the pagination in the response.
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+            description: >-
+              QueryDexPairsResponse is the response type for the Query/DexPairs
+              RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /initia/move/v1/dex/pairs/{metadata_quote}:
+    get:
+      summary: DexPair queries a dex pair by quote metadata address.
+      operationId: DexPair
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              dex_pair:
+                type: object
+                properties:
+                  metadata_quote:
+                    type: string
+                  metadata_lp:
+                    type: string
+                description: |-
+                  DexPair contains coin metadata address
+                  std::dex::Pool and std::dex::Config resources.
+            description: >-
+              QueryDexPairResponse is the response type for the Query/DexPair
+              RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: metadata_quote
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /initia/move/v1/metadata:
     get:
-      summary: Metadata converts metadata to denom
+      summary: Metadata converts denom to metadata
       operationId: Metadata
       responses:
         '200':
@@ -874,6 +1051,9 @@ paths:
 
                       and an empty list is interpreted as allowing anyone to
                       distribute.
+                  clamm_module_address:
+                    type: string
+                    title: CLAMM module address
             description: >-
               QueryParamsResponse is the response type for the Query/Params RPC
               method.
@@ -1893,6 +2073,16 @@ definitions:
               if the ACL of a address is not set,
               then we use this value to decide the ACL.
     description: QueryParamsResponse is the response type for the Query/Params RPC method.
+  initia.move.v1.DexPair:
+    type: object
+    properties:
+      metadata_quote:
+        type: string
+      metadata_lp:
+        type: string
+    description: |-
+      DexPair contains coin metadata address
+      std::dex::Pool and std::dex::Config resources.
   initia.move.v1.Module:
     type: object
     properties:
@@ -1941,6 +2131,9 @@ definitions:
         description: |-
           It is a list of addresses with permission to distribute contracts,
           and an empty list is interpreted as allowing anyone to distribute.
+      clamm_module_address:
+        type: string
+        title: CLAMM module address
     description: Params defines the set of move parameters.
   initia.move.v1.QueryDenomResponse:
     type: object
@@ -1948,6 +2141,59 @@ definitions:
       denom:
         type: string
     description: QueryDenomResponse is the response type for the Query/Denom RPC method.
+  initia.move.v1.QueryDexPairResponse:
+    type: object
+    properties:
+      dex_pair:
+        type: object
+        properties:
+          metadata_quote:
+            type: string
+          metadata_lp:
+            type: string
+        description: |-
+          DexPair contains coin metadata address
+          std::dex::Pool and std::dex::Config resources.
+    description: >-
+      QueryDexPairResponse is the response type for the Query/DexPair RPC
+      method.
+  initia.move.v1.QueryDexPairsResponse:
+    type: object
+    properties:
+      dex_pairs:
+        type: array
+        items:
+          type: object
+          properties:
+            metadata_quote:
+              type: string
+            metadata_lp:
+              type: string
+          description: |-
+            DexPair contains coin metadata address
+            std::dex::Pool and std::dex::Config resources.
+      pagination:
+        description: pagination defines the pagination in the response.
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+    description: >-
+      QueryDexPairsResponse is the response type for the Query/DexPairs RPC
+      method.
   initia.move.v1.QueryLegacyViewRequest:
     type: object
     properties:
@@ -2121,6 +2367,9 @@ definitions:
             description: |-
               It is a list of addresses with permission to distribute contracts,
               and an empty list is interpreted as allowing anyone to distribute.
+          clamm_module_address:
+            type: string
+            title: CLAMM module address
     description: QueryParamsResponse is the response type for the Query/Params RPC method.
   initia.move.v1.QueryResourceResponse:
     type: object


### PR DESCRIPTION
## Summary

- Bump `protoVer` from `0.14.0` to `0.18.1` for proto-gen and proto-pulsar-gen tasks
- Keep a pinned `swaggerProtoVer=0.14.0` image for `proto-swagger-gen` because the cloned third-party repos still expect the older swagger plugin flow
- Regenerate proto/pulsar files with the new builder (minor output changes expected)

## Test plan

- [ ] `make proto-all` completes without errors
- [ ] Generated file diffs are mechanical / non-behavioral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new DEX pair query endpoints for the Move module: list all DEX pairs and retrieve individual pair details.
  * Extended Move module parameters with CLAMM module address field.

* **Documentation**
  * Updated API documentation summaries for Move module endpoints.
  * Corrected operation identifier for consensus parameters query endpoint.

* **Chores**
  * Updated protocol buffer builder tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->