### PR TITLE
ci: validate format and go-fix in lint workflow

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build-linux-amd64:
     uses: ./.github/workflows/build-linux-amd64.yml

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-15

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-15

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04-arm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,6 +62,42 @@ jobs:
         env:
           GIT_DIFF: ${{ env.GIT_DIFF }}
           LINT_DIFF: 1
+  format:
+    runs-on: ubuntu-22.04
+    name: format
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+          check-latest: true
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
+      - name: install format tools
+        if: env.GIT_DIFF
+        run: |
+          go install github.com/client9/misspell/cmd/misspell@v0.3.4
+          go install golang.org/x/tools/cmd/goimports@latest
+        env:
+          GIT_DIFF: ${{ env.GIT_DIFF }}
+      - name: run format
+        if: env.GIT_DIFF
+        run: |
+          make format
+          CHANGES_IN_REPO=$(git status --porcelain)
+          if [[ -n "$CHANGES_IN_REPO" ]]; then
+            echo "Repository is dirty after 'make format'. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+            git status && git --no-pager diff
+            exit 1
+          fi
+        env:
+          GIT_DIFF: ${{ env.GIT_DIFF }}
   # Use --check or --exit-code when available (Go 1.19?)
   # https://github.com/golang/go/issues/27005
   tidy:

--- a/.github/workflows/modernize-go.yml
+++ b/.github/workflows/modernize-go.yml
@@ -1,0 +1,39 @@
+name: Modernize Go
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  modernize-go:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+          check-latest: true
+      - name: Modernize go code
+        run: go fix ./...
+      - uses: peter-evans/create-pull-request@v7.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: modernize go code"
+          title: "chore: modernize go code"
+          branch: "chore/modernize-go"
+          delete-branch: true
+          body: |
+            This PR applies `go fix ./...` using the repository's GitHub Actions toolchain.
+
+            It is generated automatically by `.github/workflows/modernize-go.yml`.

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,6 +3,9 @@ name: Spell Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
       - "**.mv"
       - "**.move"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/app/abcipp.go
+++ b/app/abcipp.go
@@ -2,12 +2,6 @@ package app
 
 import (
 	"cosmossdk.io/errors"
-	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
-	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
-	"github.com/cosmos/cosmos-sdk/x/authz"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	opchildante "github.com/initia-labs/OPinit/x/opchild/ante"
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
@@ -15,6 +9,13 @@ import (
 	initiaante "github.com/initia-labs/initia/app/ante"
 	initiatx "github.com/initia-labs/initia/tx"
 	appante "github.com/initia-labs/minimove/app/ante"
+
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
 func (app *MinitiaApp) setupABCIPP(mempoolMaxTxs int, appOpts servertypes.AppOptions) (

--- a/app/ante/minimal.go
+++ b/app/ante/minimal.go
@@ -3,10 +3,11 @@ package ante
 import (
 	"cosmossdk.io/errors"
 
+	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
 
 	opchildante "github.com/initia-labs/OPinit/x/opchild/ante"
 	initiaante "github.com/initia-labs/initia/app/ante"

--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -30,6 +31,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	storetypes "cosmossdk.io/store/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -537,9 +539,7 @@ func RegisterSwaggerAPI(rtr *mux.Router) {
 // GetMaccPerms returns a copy of the module account permissions
 func GetMaccPerms() map[string][]string {
 	dupMaccPerms := make(map[string][]string)
-	for k, v := range maccPerms {
-		dupMaccPerms[k] = v
-	}
+	maps.Copy(dupMaccPerms, maccPerms)
 	return dupMaccPerms
 }
 

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -69,7 +69,7 @@ func BasicManager() module.BasicManager {
 type EmptyAppOptions struct{}
 
 // Get implements AppOptions
-func (ao EmptyAppOptions) Get(o string) interface{} {
+func (ao EmptyAppOptions) Get(o string) any {
 	if o == flags.FlagHome {
 		return DefaultNodeHome
 	}

--- a/app/getter.go
+++ b/app/getter.go
@@ -3,6 +3,7 @@ package app
 import (
 	storetypes "cosmossdk.io/store/types"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/app/modules.go
+++ b/app/modules.go
@@ -76,7 +76,7 @@ var maccPerms = map[string][]string{
 	ibcfeetypes.ModuleName:          nil,
 	ibctransfertypes.ModuleName:     {authtypes.Minter, authtypes.Burner},
 	movetypes.MoveStakingModuleName: nil,
-	opchildtypes.ModuleName: {authtypes.Minter, authtypes.Burner},
+	opchildtypes.ModuleName:         {authtypes.Minter, authtypes.Burner},
 
 	// connect oracle permissions
 	oracletypes.ModuleName: nil,


### PR DESCRIPTION
## Summary

- Add `format` job to the lint workflow: runs `make format` and fails if the repo is dirty
- Add `modernize-go.yml`: weekly scheduled workflow that runs `go fix ./...` and opens a PR automatically
- Apply `make format` and `go fix ./...` locally (mechanical changes only)

## Test plan

- [ ] Lint workflow passes on this PR
- [ ] No behavioral changes in the codebase (format/modernize only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated formatting validation workflow to enforce consistent Go formatting and fail CI on unformatted changes.
  * Introduced a scheduled/manual Go modernization workflow that runs automated fixes and can open PRs with suggested updates.
* **Style**
  * Minor code cleanups and modernizations (imports, small API type adjustments, and map-copy improvements) for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->